### PR TITLE
include city.cpp in xul

### DIFF
--- a/vrbrowser/moz.build
+++ b/vrbrowser/moz.build
@@ -50,3 +50,10 @@ FINAL_TARGET_FILES += [
   '%' + CONFIG['STEAMWORKS_SDK_PATH'] + '/sdk/redistributable_bin/steam_api.dll',
   'steam_appid.txt'
 ]
+
+Library('vrbrowser')
+if CONFIG['MOZ_WIDGET_TOOLKIT'] == 'windows':
+    SOURCES += [
+        '../other-licenses/nsis/Contrib/CityHash/cityhash/city.cpp',
+    ]
+FINAL_LIBRARY = 'xul'


### PR DESCRIPTION
Firefox includes this source file in the xul library via browser/components/shell/, so toolkit/xre/ assumes it's been added. That seems like a dangerous assumption, prone to breakage; but in any case, this change fixes the problem for vrbrowser.
