### PR TITLE
support building on mac

### DIFF
--- a/vrbrowser/app/Main.cpp
+++ b/vrbrowser/app/Main.cpp
@@ -56,6 +56,13 @@ static void Output(const char *fmt, ... )
   va_end(ap);
 }
 
+#ifndef XP_WIN
+void OutputDebugString( const char *pchMsg )
+{
+  fprintf( stderr, "%s", pchMsg );
+}
+#endif
+
 //-----------------------------------------------------------------------------
 // Purpose: callback hook for debug text emitted from the Steam API
 //-----------------------------------------------------------------------------
@@ -69,7 +76,7 @@ extern "C" void __cdecl SteamAPIDebugTextHook( int nSeverity, const char *pchDeb
   {
     // place to set a breakpoint for catching API errors
     int x = 3;
-    x = x;
+    x += x;
   }
 }
 

--- a/vrbrowser/app/macbuild/Contents/MacOS-files.in
+++ b/vrbrowser/app/macbuild/Contents/MacOS-files.in
@@ -1,4 +1,5 @@
 /*.app/***
 /*.dylib
+/steam_appid.txt
 /vrbrowser
 /XUL

--- a/vrbrowser/app/moz.build
+++ b/vrbrowser/app/moz.build
@@ -20,6 +20,12 @@ JS_PREFERENCE_FILES += [
     'prefs.js',
 ]
 
-OS_LIBS += [
-  CONFIG['STEAMWORKS_SDK_PATH'] + '/sdk/redistributable_bin/steam_api',
-]
+if CONFIG['OS_ARCH'] == 'WINNT':
+  OS_LIBS += [
+    CONFIG['STEAMWORKS_SDK_PATH'] + '/sdk/redistributable_bin/steam_api',
+  ]
+elif CONFIG['OS_ARCH'] == 'Darwin':
+  OS_LIBS += [
+    '-L' + CONFIG['STEAMWORKS_SDK_PATH'] + '/sdk/redistributable_bin/osx32',
+    'steam_api',
+  ]

--- a/vrbrowser/moz.build
+++ b/vrbrowser/moz.build
@@ -47,9 +47,17 @@ EXPORTS.steam += [
 ]
 
 FINAL_TARGET_FILES += [
-  '%' + CONFIG['STEAMWORKS_SDK_PATH'] + '/sdk/redistributable_bin/steam_api.dll',
   'steam_appid.txt'
 ]
+
+if CONFIG['OS_ARCH'] == 'WINNT':
+  FINAL_TARGET_FILES += [
+    '%' + CONFIG['STEAMWORKS_SDK_PATH'] + '/sdk/redistributable_bin/steam_api.dll',
+  ]
+elif CONFIG['OS_ARCH'] == 'Darwin':
+  FINAL_TARGET_FILES += [
+    '%' + CONFIG['STEAMWORKS_SDK_PATH'] + '/sdk/redistributable_bin/osx32/libsteam_api.dylib',
+  ]
 
 Library('vrbrowser')
 if CONFIG['MOZ_WIDGET_TOOLKIT'] == 'windows':


### PR DESCRIPTION
@dmarcos This changeset does a few things to enable building on Mac:

* OutputDebugString isn't defined on Mac (and presumably not on Linux either, since it's [part of the Windows API](https://msdn.microsoft.com/en-us/library/windows/desktop/aa363362(v=vs.85).aspx)), so this changeset defines it `#ifndef XP_WIN`.
* My compiler warned about `explicitly assigning a variable of type 'int' to itself`, and since I have `ac_add_options --enable-warnings-as-errors`, that turned into an error. This changeset fixes that by adding the variable by itself instead (which shouldn't matter, since the statement is only present in order to be a debugging breakpoint target).
* The steam_api library is located in a different directory for macOS, and it needs to be found in a different way, so this changeset modifies the build config to find it.

With these changes, the app builds, but running it fails with:

> [S_API FAIL] SteamAPI_Init() failed; ipcserver init failed .
> [S_API FAIL] SteamAPI_Init() failed; unable to locate a running instance of Steam, or a local steamclient.dylib.
> SteamAPI_Init() failed

However, if I comment out the Steam initialization code in Main.cpp, then the app builds and runs successfully, no crashes.
