### PR TITLE
look for Runtime.jsm in the gre/modules/ dir

### DIFF
--- a/vrbrowser/components/CommandLineHandler.js
+++ b/vrbrowser/components/CommandLineHandler.js
@@ -4,7 +4,7 @@
 
 const { classes: Cc, interfaces: Ci, results: Cr, utils: Cu } = Components;
 
-Cu.import("resource:///modules/Runtime.jsm");
+Cu.import("resource://gre/modules/Runtime.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 


### PR DESCRIPTION
We should be looking for it in an app-specific modules dir
(even if they point to the same on-disk directory), but I can't
seem to figure out how to configure one of those at the moment.
So this is a stopgap solution.