### PR TITLE
fix building with sandbox

### DIFF
--- a/vrbrowser/app/Main.cpp
+++ b/vrbrowser/app/Main.cpp
@@ -23,6 +23,8 @@
 
 mozilla::Bootstrap::UniquePtr gBootstrap;
 
+using namespace mozilla;
+
 #define kDesktopFolder "vrbrowser"
 
 static void Output(const char *fmt, ... )

--- a/vrbrowser/app/moz.build
+++ b/vrbrowser/app/moz.build
@@ -29,3 +29,19 @@ elif CONFIG['OS_ARCH'] == 'Darwin':
     '-L' + CONFIG['STEAMWORKS_SDK_PATH'] + '/sdk/redistributable_bin/osx32',
     'steam_api',
   ]
+
+if CONFIG['MOZ_SANDBOX'] and CONFIG['OS_ARCH'] == 'WINNT':
+    # For sandbox includes and the include dependencies those have
+    LOCAL_INCLUDES += [
+        '/security/sandbox/chromium',
+        '/security/sandbox/chromium-shim',
+    ]
+
+    USE_LIBS += [
+        'sandbox_s',
+    ]
+
+    DELAYLOAD_DLLS += [
+        'winmm.dll',
+        'user32.dll',
+    ]


### PR DESCRIPTION
@dmarcos This fixes building with a sandbox, but the build still crashes on Windows, although the crash looks different. My optimized build hits this assertion:

> Assertion failure: loc->kind() != NameLocation::Kind::FrameSlot, at c:/Users/myk/Projects/gecko/js/src/frontend/BytecodeEmitter.cpp:808
